### PR TITLE
Fix roster character expansion

### DIFF
--- a/src/app/components/RosterCard.tsx
+++ b/src/app/components/RosterCard.tsx
@@ -13,36 +13,39 @@ export default function RosterCard({ character, isExpanded, onToggle }: RosterCa
   // The internal 'isExpanded' state has been removed.
 
   return (
-    <div 
-      className="bg-gray-900 rounded-lg overflow-hidden cursor-pointer transition-all duration-300 ease-in-out hover:ring-2 hover:ring-blue-500"
-      onClick={onToggle} // Use the onToggle handler from props
-    >
-      {/* Collapsed View */}
-      <div className="flex items-center p-4">
-        <div className="w-16 h-16 flex-shrink-0 relative mr-4">
-          <Image src={character.imageUrl} alt={character.name} layout="fill" objectFit="cover" className="rounded-md" />
-        </div>
-        <div>
-          <h3 className="text-xl font-bold text-white">{character.name}</h3>
-          <p className="text-sm text-gray-400">{character.isUnlocked ? 'Unlocked' : 'Locked'}</p>
-        </div>
-      </div>
-
-      {/* Expanded View */}
-      {/* The expansion is now controlled by the 'isExpanded' prop */}
-      <div className={`transition-all duration-300 ease-in-out ${isExpanded ? 'max-h-96' : 'max-h-0'}`}>
-        <div className="p-4 border-t border-gray-700">
-          <h4 className="font-semibold text-blue-300 mb-2">Skills:</h4>
-          <div className="space-y-2">
-            {character.skills.map(skill => (
-              <div key={skill.id} className="text-sm">
-                <p className="font-bold">{skill.name}</p>
-                <p className="text-gray-400 text-xs">{skill.description}</p>
-              </div>
-            ))}
+    <div className="relative"> {/* Added relative positioning container */}
+      <div 
+        className="bg-gray-900 rounded-lg overflow-hidden cursor-pointer transition-all duration-300 ease-in-out hover:ring-2 hover:ring-blue-500"
+        onClick={onToggle} // Use the onToggle handler from props
+      >
+        {/* Collapsed View */}
+        <div className="flex items-center p-4">
+          <div className="w-16 h-16 flex-shrink-0 relative mr-4">
+            <Image src={character.imageUrl} alt={character.name} layout="fill" objectFit="cover" className="rounded-md" />
+          </div>
+          <div>
+            <h3 className="text-xl font-bold text-white">{character.name}</h3>
+            <p className="text-sm text-gray-400">{character.isUnlocked ? 'Unlocked' : 'Locked'}</p>
           </div>
         </div>
       </div>
+
+      {/* Expanded View - Now positioned absolutely to avoid affecting grid layout */}
+      {isExpanded && (
+        <div className="absolute top-full left-0 right-0 bg-gray-900 rounded-b-lg border border-gray-700 border-t-0 z-10 shadow-xl">
+          <div className="p-4">
+            <h4 className="font-semibold text-blue-300 mb-2">Skills:</h4>
+            <div className="space-y-2">
+              {character.skills.map(skill => (
+                <div key={skill.id} className="text-sm">
+                  <p className="font-bold">{skill.name}</p>
+                  <p className="text-gray-400 text-xs">{skill.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Refactor RosterCard expansion to use absolute positioning, fixing the issue where clicking a portrait expanded the entire row.

The previous implementation used `max-height` transitions which, in a grid layout, caused the entire row's height to adjust, making it appear as if all cards in that row were expanding. By switching to absolute positioning for the expanded content, the expansion is now an overlay that does not affect the grid's flow, ensuring only the clicked card visually expands.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a664029f-92ab-44fd-a4c7-be91377251e7) · [Cursor](https://cursor.com/background-agent?bcId=bc-a664029f-92ab-44fd-a4c7-be91377251e7)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)