### PR TITLE
Fix roster character expansion

### DIFF
--- a/src/app/(protected)/roster/page.tsx
+++ b/src/app/(protected)/roster/page.tsx
@@ -73,7 +73,7 @@ export default function RosterPage() {
       </div>
 
       <div className="flex-grow p-4 overflow-y-auto">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 items-start">
           {filteredRoster.map(character => (
             <RosterCard 
               key={character.id} 

--- a/src/app/components/RosterCard.tsx
+++ b/src/app/components/RosterCard.tsx
@@ -10,42 +10,38 @@ interface RosterCardProps {
 }
 
 export default function RosterCard({ character, isExpanded, onToggle }: RosterCardProps) {
-  // The internal 'isExpanded' state has been removed.
-
   return (
-    <div className="relative"> {/* Added relative positioning container */}
-      <div 
-        className="bg-gray-900 rounded-lg overflow-hidden cursor-pointer transition-all duration-300 ease-in-out hover:ring-2 hover:ring-blue-500"
-        onClick={onToggle} // Use the onToggle handler from props
-      >
-        {/* Collapsed View */}
-        <div className="flex items-center p-4">
-          <div className="w-16 h-16 flex-shrink-0 relative mr-4">
-            <Image src={character.imageUrl} alt={character.name} layout="fill" objectFit="cover" className="rounded-md" />
-          </div>
-          <div>
-            <h3 className="text-xl font-bold text-white">{character.name}</h3>
-            <p className="text-sm text-gray-400">{character.isUnlocked ? 'Unlocked' : 'Locked'}</p>
-          </div>
+    <div 
+      className="bg-gray-900 rounded-lg overflow-hidden cursor-pointer transition-all duration-300 ease-in-out hover:ring-2 hover:ring-blue-500"
+      onClick={onToggle}
+    >
+      {/* Collapsed View */}
+      <div className="flex items-center p-4">
+        <div className="w-16 h-16 flex-shrink-0 relative mr-4">
+          <Image src={character.imageUrl} alt={character.name} layout="fill" objectFit="cover" className="rounded-md" />
+        </div>
+        <div>
+          <h3 className="text-xl font-bold text-white">{character.name}</h3>
+          <p className="text-sm text-gray-400">{character.isUnlocked ? 'Unlocked' : 'Locked'}</p>
         </div>
       </div>
 
-      {/* Expanded View - Now positioned absolutely to avoid affecting grid layout */}
-      {isExpanded && (
-        <div className="absolute top-full left-0 right-0 bg-gray-900 rounded-b-lg border border-gray-700 border-t-0 z-10 shadow-xl">
-          <div className="p-4">
-            <h4 className="font-semibold text-blue-300 mb-2">Skills:</h4>
-            <div className="space-y-2">
-              {character.skills.map(skill => (
-                <div key={skill.id} className="text-sm">
-                  <p className="font-bold">{skill.name}</p>
-                  <p className="text-gray-400 text-xs">{skill.description}</p>
-                </div>
-              ))}
-            </div>
+      {/* Expanded View - Using proper height transitions that respect document flow */}
+      <div className={`overflow-hidden transition-all duration-300 ease-in-out ${
+        isExpanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+      }`}>
+        <div className="p-4 border-t border-gray-700 bg-gray-800">
+          <h4 className="font-semibold text-blue-300 mb-2">Skills:</h4>
+          <div className="space-y-2">
+            {character.skills.map(skill => (
+              <div key={skill.id} className="text-sm">
+                <p className="font-bold text-white">{skill.name}</p>
+                <p className="text-gray-400 text-xs">{skill.description}</p>
+              </div>
+            ))}
           </div>
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fix roster card expansion to only expand the clicked character and push down subsequent content.

Initially, an absolute positioning approach was used to prevent row-wide expansion, but this caused content overlap. This PR reverts to a document flow expansion with `items-start` on the grid to ensure content pushes down correctly without affecting other cards in the row.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-a664029f-92ab-44fd-a4c7-be91377251e7) · [Cursor](https://cursor.com/background-agent?bcId=bc-a664029f-92ab-44fd-a4c7-be91377251e7)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)