### PR TITLE
Add skill icons to Roster page

### DIFF
--- a/src/app/components/RosterCard.tsx
+++ b/src/app/components/RosterCard.tsx
@@ -63,7 +63,7 @@ export default function RosterCard({ character, isExpanded, onToggle }: RosterCa
                 {/* Skill Info */}
                 <div className="flex-grow min-w-0">
                   <p className="font-bold text-white">{skill.name}</p>
-                  <p className="text-gray-400 text-xs truncate">{skill.description}</p>
+                  <p className="text-gray-400 text-xs">{skill.description}</p>
                 </div>
               </div>
             ))}


### PR DESCRIPTION
Remove `truncate` class from skill descriptions to display them in full.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-48159efe-d4cc-4d2e-b839-a5457ad30a18) · [Cursor](https://cursor.com/background-agent?bcId=bc-48159efe-d4cc-4d2e-b839-a5457ad30a18)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)